### PR TITLE
Продвинутые линтеры

### DIFF
--- a/duplicates_log/main.go
+++ b/duplicates_log/main.go
@@ -39,8 +39,8 @@ func (fs *FSImpl) Remove(input string) error {
 	return os.Remove(input)
 }
 
-func (fs *FSImpl) Chdir(input string) {
-	os.Chdir(input)
+func (fs *FSImpl) Chdir(input string) error {
+	return os.Chdir(input)
 }
 
 func (fs *FSImpl) ReadDir(input string) ([]fs.DirEntry, error) {
@@ -194,7 +194,12 @@ func deleteDuplicates(copNum []int, number int) {
 		if numberDelete == 0 {
 			return
 		}
-		myfs.Chdir(allFiles[copNum[numberDelete-2]].filePath)
+		err = myfs.Chdir(allFiles[copNum[numberDelete-2]].filePath)
+		if err != nil {
+			fmt.Println("Error changing directory.")
+			hlog.WithFields(log.Fields{"file": strings.Join([]string{allFiles[copNum[numberDelete-2]].filePath, allFiles[copNum[numberDelete-2]].fileName}, "\\")}).Error("Error changing directory.")
+			return
+		}
 		err = myfs.Remove(allFiles[copNum[numberDelete-2]].fileName)
 		if err != nil {
 			fmt.Println("File not deleted. Error occured.")


### PR DESCRIPTION
Вывод golangci-lint:
duplicates_log\main.go:50:6: `FS` is unused (deadcode)
type FS interface {
     ^
duplicates_log\main.go:43:10: Error return value of `os.Chdir` is not checked (errcheck)
        os.Chdir(input)
                ^

Реализация:
1. Интерфейс FS сделан для тестирования.
2. Добавила проверку на ошибку с логированием.